### PR TITLE
Fix for file_exist repo checks when not policy is specified

### DIFF
--- a/src/evaluators/RepoPolicyEvaluator.ts
+++ b/src/evaluators/RepoPolicyEvaluator.ts
@@ -64,7 +64,7 @@ export class RepoPolicyEvaluator {
     }
 
     // Check the files exist policy rule
-    if (this.policy.file_exists.length > 0) {
+    if (this.policy.file_exists && this.policy.file_exists.length > 0) {
       const files_exist = await new FilesExistChecks(
         this.repository,
         this.policy,


### PR DESCRIPTION
This PR quickly fixes a bug when `this.policy.file_exists.length` is `undefined` and allows the tool to continue till the end.