### PR TITLE
fix workflow for new v1.1

### DIFF
--- a/.github/workflows/gitarmor-on-demand.yml
+++ b/.github/workflows/gitarmor-on-demand.yml
@@ -11,10 +11,19 @@ on:
         description: 'Organization name'
         required: true
         default: 'dearmory'
+      debug:
+        description: 'Enable debug output (true/false)'
+        required: false
+        default: 'false'
       level:
-        description: 'Level'
+        description: 'Level (repository_only, organization_only, organization_and_repository)'
         required: true
-        default: 'repository'
+        type: choice
+        options:
+          - repository_only
+          - organization_only
+          - organization_and_repository
+        default: 'repository_only'
 
 jobs:
   run-gitarmor:
@@ -40,7 +49,8 @@ jobs:
           repo: ${{ github.event.inputs.repo }}
           org: ${{ github.event.inputs.org }}
           token: ${{ steps.app-token.outputs.token }}
-          level: ${{ github.event.inputs.level }}
+      level: ${{ github.event.inputs.level }}
+      debug: ${{ github.event.inputs.debug }}
           policy-dir: './policies'
 
     - name: Print report to Job summary

--- a/.github/workflows/gitarmor-scheduled.yml
+++ b/.github/workflows/gitarmor-scheduled.yml
@@ -28,8 +28,16 @@ jobs:
           repo: ${{ github.repository }}
           org: ${{ github.repository_owner }}
           token: ${{ steps.app-token.outputs.token }}
-          level: 'organization'
+          level: 'organization_only'
+          debug: 'false'
           policy-dir: './policies'
 
-    - name: Get the output
-      run: echo "Check results - ${{ steps.gitarmor.outputs.check-results }}"
+    - name: Print report to Job summary
+      run: |
+        cat output-report.md >> $GITHUB_STEP_SUMMARY
+
+    - name: Upload the reports as Actions artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: gitarmor-evaluation-report
+        path: output-report.*


### PR DESCRIPTION
Fixed workflow input for v1.1

This pull request updates the GitHub Actions workflows for GitArmor to improve configuration flexibility and reporting. The main changes include enhanced input options for running GitArmor, better debug support, and improved reporting and artifact handling in the scheduled workflow.

**Workflow input enhancements:**

* Added a `debug` input to both `gitarmor-on-demand` and `gitarmor-scheduled` workflows, allowing users to enable debug output if needed. [[1]](diffhunk://#diff-8bc1c288e1f1ab292b03ad415d20827d5c22b2c4545d6ebfed9f7ef4832292a8R14-R26) [[2]](diffhunk://#diff-9ef55321939609d7217ae7bc197b40e7a34be263fce77e2267a7676e479d2ebfL31-R43)
* Updated the `level` input in `gitarmor-on-demand` to a choice type with clearer options (`repository_only`, `organization_only`, `organization_and_repository`), improving usability.

**Reporting and artifact improvements:**

* Changed the scheduled workflow to print the evaluation report to the job summary and upload the report as an Actions artifact for easier access and review.

**Workflow parameter propagation:**

* Ensured that the new `debug` and updated `level` inputs are correctly passed to the GitArmor job steps in both workflows. [[1]](diffhunk://#diff-8bc1c288e1f1ab292b03ad415d20827d5c22b2c4545d6ebfed9f7ef4832292a8R53) [[2]](diffhunk://#diff-9ef55321939609d7217ae7bc197b40e7a34be263fce77e2267a7676e479d2ebfL31-R43)